### PR TITLE
Native transfers and ez stats models

### DIFF
--- a/.github/workflows/dbt_run_non_core.yml
+++ b/.github/workflows/dbt_run_non_core.yml
@@ -1,0 +1,46 @@
+name: dbt_run_non_core
+run-name: dbt_run_non_core
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   # Runs "at minute 7 and 37, every hour" (see https://crontab.guru)
+  #   - cron: '10 * * * *'
+
+env:
+  USE_VARS: "${{ vars.USE_VARS }}"
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+  DBT_VERSION: "${{ vars.DBT_VERSION }}"
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ vars.PYTHON_VERSION }}"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+      - name: Run DBT Jobs
+        run: |
+          dbt run -m "aleo_models,tag:noncore"

--- a/data/github_actions__workflows.csv
+++ b/data/github_actions__workflows.csv
@@ -2,5 +2,5 @@ workflow_name,workflow_schedule
 dbt_run_streamline_blocks_realtime,"5,35 * * * *"
 dbt_run_core,"20,50 * * * *"
 dbt_test_tasks,"0,30 * * * *"
-dbt_run_non_core,"30,50 * * * *"
+dbt_run_non_core,"25,55 * * * *"
 dbt_test_recent,"20 */4 * * *"

--- a/models/descriptions/__overview__.md
+++ b/models/descriptions/__overview__.md
@@ -28,6 +28,7 @@ There is more information on how to use dbt docs in the last section of this doc
 - [core.fact_blocks](https://flipsidecrypto.github.io/aleo-models/#!/model/model.aleo_models.core__fact_blocks)
 - [core.fact_transactions](https://flipsidecrypto.github.io/aleo-models/#!/model/model.aleo_models.core__fact_transactions)
 - [core.fact_transitions](https://flipsidecrypto.github.io/aleo-models/#!/model/model.aleo_models.core__fact_transitions)
+- [core.fact_transfers](https://flipsidecrypto.github.io/aleo-models/#!/model/model.aleo_models.core__fact_transfers)
 
 **Convenience Tables:**
 More to come.

--- a/models/descriptions/fee.md
+++ b/models/descriptions/fee.md
@@ -1,0 +1,5 @@
+{% docs fee %}
+
+The native-unit fee value from the transaction.
+
+{% enddocs %}

--- a/models/descriptions/fee_payer.md
+++ b/models/descriptions/fee_payer.md
@@ -1,0 +1,5 @@
+{% docs fee_payer %}
+
+The account that paid the fee for the transaction.
+
+{% enddocs %}

--- a/models/descriptions/fee_raw.md
+++ b/models/descriptions/fee_raw.md
@@ -1,0 +1,5 @@
+{% docs fee_raw %}
+
+The raw fee value from the transaction.
+
+{% enddocs %}

--- a/models/descriptions/transfer_type.md
+++ b/models/descriptions/transfer_type.md
@@ -1,0 +1,5 @@
+{% docs transfer_type %}
+
+The type of transfer, namely public or private.
+
+{% enddocs %}

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -79,6 +79,7 @@ SELECT
         fee,
         0
     ) AS fee,
+    b.fee_payer,
     {{ dbt_utils.generate_surrogate_key(['a.tx_id']) }} AS fact_transactions_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -5,7 +5,7 @@
     incremental_strategy = 'merge',
     merge_exclude_columns = ['inserted_timestamp'],
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_id,fee_msg,execution_msg,deployment_msg,owner_msg,finalize_msg,rejected_msg);",
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_id,fee_msg,execution_msg,deployment_msg,owner_msg,finalize_msg,rejected_msg,fee_payer);",
     tags = ['core', 'full_test']
 ) }}
 

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -55,6 +55,18 @@ models:
         description: "{{ doc('tx_transition_count') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+      - name: FEE_RAW
+        description: "{{ doc('fee_raw') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: FEE
+        description: "{{ doc('fee') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: FEE_PAYER
+        description: "{{ doc('fee_payer') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
       - name: FACT_TRANSACTIONS_ID
         description: '{{ doc("pk") }}'
       - name: INSERTED_TIMESTAMP

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -1,0 +1,45 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_predicates = ["COALESCE(DBT_INTERNAL_DEST.block_timestamp::DATE,'2099-12-31') >= (select min(block_timestamp::DATE) from " ~ generate_tmp_view_name(this) ~ ")"],
+    unique_key = ['transition_id'],
+    incremental_strategy = 'merge',
+    merge_exclude_columns = ["inserted_timestamp"],
+    cluster_by = ['block_timestamp::DATE'],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(tx_id,sender,receiver);",
+    tags = ['core','full_test']
+) }}
+
+SELECT
+    block_id,
+    block_timestamp,
+    tx_id,
+    tx_succeeded,
+    transition_id,
+    transfer_type,
+    sender,
+    receiver,
+    amount,
+    currency,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_id','transition_id','transfer_type']
+    ) }} AS fact_transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    {{ ref('silver__native_transfers') }}
+
+{% if is_incremental() %}
+WHERE
+    modified_timestamp >= DATEADD(
+        'minute',
+        -5,(
+            SELECT
+                MAX(
+                    modified_timestamp
+                )
+            FROM
+                {{ this }}
+        )
+    )
+{% endif %}

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -19,7 +19,8 @@ SELECT
     sender,
     receiver,
     amount,
-    currency,
+    NULL AS token_address,
+    TRUE AS is_native,
     {{ dbt_utils.generate_surrogate_key(
         ['tx_id','transition_id','transfer_type']
     ) }} AS fact_transfers_id,

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -15,12 +15,13 @@ SELECT
     tx_id,
     tx_succeeded,
     transition_id,
+    index,
     transfer_type,
     sender,
     receiver,
     amount,
-    NULL AS token_address,
-    TRUE AS is_native,
+    is_native,
+    token_address,
     {{ dbt_utils.generate_surrogate_key(
         ['tx_id','transition_id','transfer_type']
     ) }} AS fact_transfers_id,

--- a/models/gold/core/core__fact_transfers.yml
+++ b/models/gold/core/core__fact_transfers.yml
@@ -1,0 +1,47 @@
+version: 2
+models:
+  - name: core__fact_transfers
+    description: Records of all wallet to wallet transfers on Aleo.
+    columns:
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests: 
+          - dbt_expectations.expect_column_to_exist
+      - name: TX_SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests: 
+          - dbt_expectations.expect_column_to_exist
+      - name: TRANSFER_TYPE
+        description: "{{ doc('transfer_type') }}"
+        tests: 
+          - dbt_expectations.expect_column_to_exist
+      - name: SENDER
+        description: "Address that tokens are transferred from."
+        tests: 
+          - dbt_expectations.expect_column_to_exist
+      - name: RECEIVER
+        description: "Address that tokens are transferred to."
+        tests: 
+          - dbt_expectations.expect_column_to_exist
+      - name: AMOUNT
+        description: "Number of tokens transferred."
+        tests: 
+          - dbt_expectations.expect_column_to_exist
+      - name: CURRENCY
+        description: "Currency of the transfer."
+        tests: 
+          - dbt_expectations.expect_column_to_exist
+      - name: FACT_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'          

--- a/models/gold/core/core__fact_transfers.yml
+++ b/models/gold/core/core__fact_transfers.yml
@@ -38,8 +38,12 @@ models:
         description: "Number of tokens transferred."
         tests: 
           - dbt_expectations.expect_column_to_exist
-      - name: CURRENCY
-        description: "Currency of the transfer."
+      - name: IS_NATIVE
+        description: "Whether the transfer is a native transfer."
+        tests: 
+          - dbt_expectations.expect_column_to_exist
+      - name: TOKEN_ADDRESS 
+        description: "Token address of the transfer."
         tests: 
           - dbt_expectations.expect_column_to_exist
       - name: FACT_TRANSFERS_ID

--- a/models/gold/core/core__fact_transfers.yml
+++ b/models/gold/core/core__fact_transfers.yml
@@ -11,6 +11,9 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
       - name: TX_ID
         description: "{{ doc('tx_id') }}"
         tests: 

--- a/models/gold/core/tests/transfers/test_core__transfers_full.sql
+++ b/models/gold/core/tests/transfers/test_core__transfers_full.sql
@@ -1,0 +1,9 @@
+{{ config (
+    materialized = 'view',
+    tags = ['full_test']
+) }}
+
+SELECT
+    *
+FROM
+    {{ ref('core__fact_transfers') }}

--- a/models/gold/core/tests/transfers/test_core__transfers_full.yml
+++ b/models/gold/core/tests/transfers/test_core__transfers_full.yml
@@ -68,11 +68,18 @@ models:
           - not_null:
               where: transfer_type != 'transfer_private'
           - dbt_expectations.expect_column_values_to_be_of_type:
-              column_type: NUMBER
-      - name: CURRENCY
-        description: "Currency of the transfer."
+              column_type: FLOAT
+      - name: IS_NATIVE
+        description: "Whether the transfer is a native transfer."
         tests: 
           - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: BOOLEAN
+      - name: TOKEN_ADDRESS
+        description: "Token address of the transfer."
+        tests: 
+          - not_null:
+              where: is_native = FALSE
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: VARCHAR
       - name: FACT_TRANSFERS_ID

--- a/models/gold/core/tests/transfers/test_core__transfers_full.yml
+++ b/models/gold/core/tests/transfers/test_core__transfers_full.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: test_core__transfers_recent
+  - name: test_core__transfers_full
     description: Records of all address to address transfers on Aleo.
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/models/gold/core/tests/transfers/test_core__transfers_full.yml
+++ b/models/gold/core/tests/transfers/test_core__transfers_full.yml
@@ -1,0 +1,83 @@
+version: 2
+models:
+  - name: test_core__transfers_recent
+    description: Records of all address to address transfers on Aleo.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TRANSITION_ID
+            - TX_ID
+            - BLOCK_ID
+    columns:
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: NUMBER
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp_ntz
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+      - name: TX_SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: BOOLEAN
+      - name: TRANSITION_ID
+        description: "{{ doc('transition_id') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+      - name: TRANSFER_TYPE
+        description: "{{ doc('transfer_type') }}"
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+      - name: SENDER
+        description: "Address that tokens are transferred from."
+        tests: 
+          - not_null:
+              where: transfer_type IN ('transfer_public', 'transfer_public_as_signer', 'transfer_public_to_private')
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+      - name: RECEIVER
+        description: "Address that tokens are transferred to."
+        tests: 
+          - not_null:
+              where: transfer_type IN ('transfer_public', 'transfer_public_as_signer', 'transfer_private_to_public')
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+      - name: AMOUNT
+        description: "Number of tokens transferred."
+        tests: 
+          - not_null:
+              where: transfer_type != 'transfer_private'
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: NUMBER
+      - name: CURRENCY
+        description: "Currency of the transfer."
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+      - name: FACT_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'          

--- a/models/gold/core/tests/transfers/test_core__transfers_recent.sql
+++ b/models/gold/core/tests/transfers/test_core__transfers_recent.sql
@@ -1,0 +1,27 @@
+{{ config (
+    materialized = 'view',
+    tags = ['recent_test']
+) }}
+
+WITH last_3_days AS (
+
+    SELECT
+        block_date
+    FROM
+        {{ ref("_max_block_by_date") }}
+        qualify ROW_NUMBER() over (
+            ORDER BY
+                block_date DESC
+        ) = 3
+)
+SELECT
+    *
+FROM
+    {{ ref('core__fact_transfers') }}
+WHERE
+    block_timestamp :: DATE >= (
+        SELECT
+            block_date
+        FROM
+            last_3_days
+    )

--- a/models/gold/core/tests/transfers/test_core__transfers_recent.yml
+++ b/models/gold/core/tests/transfers/test_core__transfers_recent.yml
@@ -55,11 +55,18 @@ models:
         description: "Number of tokens transferred."
         tests: 
           - dbt_expectations.expect_column_values_to_be_of_type:
-              column_type: NUMBER
-      - name: CURRENCY
-        description: "Currency of the transfer."
+              column_type: FLOAT
+      - name: IS_NATIVE
+        description: "Whether the transfer is a native transfer."
         tests: 
           - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: BOOLEAN
+      - name: TOKEN_ADDRESS
+        description: "Token address of the transfer."
+        tests: 
+          - not_null:
+              where: is_native = FALSE
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: VARCHAR
       - name: FACT_TRANSFERS_ID

--- a/models/gold/core/tests/transfers/test_core__transfers_recent.yml
+++ b/models/gold/core/tests/transfers/test_core__transfers_recent.yml
@@ -1,0 +1,70 @@
+version: 2
+models:
+  - name: test_core__transfers_recent
+    description: Records of all address to address transfers on Aleo.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TRANSITION_ID
+            - TX_ID
+            - BLOCK_ID
+    columns:
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: timestamp_ntz
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: hour
+              interval: 3
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests:
+          - not_null
+      - name: TRANSITION_ID
+        description: "{{ doc('transition_id') }}"
+        tests:
+          - not_null
+      - name: INDEX
+        tests:
+          - not_null
+      - name: TX_SUCCEEDED
+        description: "{{ doc('tx_succeeded') }}"
+        tests:
+          - not_null
+      - name: TRANSFER_TYPE
+        description: "{{ doc('transfer_type') }}"
+        tests: 
+          - not_null
+      - name: SENDER
+        description: "Address that tokens are transferred from."
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+      - name: RECEIVER
+        description: "Address that tokens are transferred to."
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+      - name: AMOUNT
+        description: "Number of tokens transferred."
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: NUMBER
+      - name: CURRENCY
+        description: "Currency of the transfer."
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: VARCHAR
+      - name: FACT_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'          

--- a/models/gold/stats/stats__ez_core_metrics_hourly.sql
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.sql
@@ -57,12 +57,16 @@ WITH txs AS (
 
     {% if is_incremental() %}
     WHERE
-        block_timestamp_hour >= (
-            SELECT
-                MAX(block_timestamp_hour)
-            FROM
-                {{ this }}
-        ) - INTERVAL '1 hour'
+        block_timestamp_hour >= LEAST(
+            COALESCE(
+                '{{ min_block_timestamp_hour_blocks }}',
+                '2000-01-01'
+            ),
+            COALESCE(
+                '{{ min_block_timestamp_hour_txns }}',
+                '2000-01-01'
+            )
+        )
     {% endif %}
 ),
 blocks AS (

--- a/models/gold/stats/stats__ez_core_metrics_hourly.sql
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.sql
@@ -23,3 +23,13 @@ SELECT
     modified_timestamp
 FROM
     {{ ref('silver_stats__core_metrics_hourly') }}
+
+{% if is_incremental() %}
+WHERE
+    block_timestamp_hour >= (
+        SELECT
+            MAX(block_timestamp_hour)
+        FROM
+            {{ this }}
+    ) - INTERVAL '1 hour'
+{% endif %}

--- a/models/gold/stats/stats__ez_core_metrics_hourly.sql
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.sql
@@ -1,0 +1,26 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_timestamp_hour",
+    cluster_by = ['block_timestamp_hour::DATE'],
+    tags = ['noncore','recent_test'],
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'STATS, METRICS, CORE, HOURLY',
+    }} }
+) }}
+
+SELECT
+    block_timestamp_hour,
+    block_id_min,
+    block_id_max,
+    block_count,
+    transaction_count,
+    transaction_count_success,
+    transaction_count_failed,
+    unique_from_count,
+    unique_to_count,
+    total_fees AS total_fees_native,
+    core_metrics_hourly_id AS ez_core_metrics_hourly_id,
+    inserted_timestamp,
+    modified_timestamp
+FROM
+    {{ ref('silver_stats__core_metrics_hourly') }}

--- a/models/gold/stats/stats__ez_core_metrics_hourly.sql
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.sql
@@ -17,7 +17,6 @@ SELECT
     transaction_count_success,
     transaction_count_failed,
     unique_from_count,
-    unique_to_count,
     total_fees AS total_fees_native,
     core_metrics_hourly_id AS ez_core_metrics_hourly_id,
     inserted_timestamp,

--- a/models/gold/stats/stats__ez_core_metrics_hourly.sql
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.sql
@@ -7,29 +7,109 @@
     meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'STATS, METRICS, CORE, HOURLY',
     }} }
 ) }}
-
-SELECT
-    block_timestamp_hour,
-    block_id_min,
-    block_id_max,
-    block_count,
-    transaction_count,
-    transaction_count_success,
-    transaction_count_failed,
-    unique_from_count,
-    total_fees AS total_fees_native,
-    core_metrics_hourly_id AS ez_core_metrics_hourly_id,
-    inserted_timestamp,
-    modified_timestamp
-FROM
-    {{ ref('silver_stats__core_metrics_hourly') }}
+-- depends_on: {{ ref('core__fact_blocks') }}
+-- depends_on: {{ ref('core__fact_transactions') }}
+{% if execute %}
 
 {% if is_incremental() %}
+{% set query %}
+
+SELECT
+    MIN(DATE_TRUNC('hour', block_timestamp)) block_timestamp_hour
+FROM
+    {{ ref('core__fact_blocks') }}
 WHERE
-    block_timestamp_hour >= (
+    modified_timestamp >= (
         SELECT
-            MAX(block_timestamp_hour)
+            MAX(modified_timestamp)
         FROM
             {{ this }}
-    ) - INTERVAL '1 hour'
+    ) {% endset %}
+    {% set min_block_timestamp_hour_blocks = run_query(query).columns [0].values() [0] %}
+    {% set query2 %}
+SELECT
+    MIN(DATE_TRUNC('hour', block_timestamp)) block_timestamp_hour
+FROM
+    {{ ref('core__fact_transactions') }}
+WHERE
+    modified_timestamp >= (
+        SELECT
+            MAX(modified_timestamp)
+        FROM
+            {{ this }}
+    ) {% endset %}
+    {% set min_block_timestamp_hour_txns = run_query(query2).columns [0].values() [0] %}
 {% endif %}
+{% endif %}
+WITH txs AS (
+    SELECT
+        block_timestamp_hour,
+        transaction_count,
+        transaction_count_success,
+        transaction_count_failed,
+        unique_from_count,
+        total_fees AS total_fees_native,
+        core_metrics_hourly_id AS ez_core_metrics_hourly_id,
+        inserted_timestamp,
+        modified_timestamp
+    FROM
+        {{ ref('silver_stats__core_metrics_hourly') }}
+
+    {% if is_incremental() %}
+    WHERE
+        block_timestamp_hour >= (
+            SELECT
+                MAX(block_timestamp_hour)
+            FROM
+                {{ this }}
+        ) - INTERVAL '1 hour'
+    {% endif %}
+),
+blocks AS (
+    SELECT
+        block_timestamp_hour,
+        block_id_min,
+        block_id_max,
+        block_count,
+        core_metrics_block_hourly_id,
+        inserted_timestamp,
+        modified_timestamp
+    FROM
+        {{ ref('silver_stats__core_metrics_block_hourly') }}
+    {% if is_incremental() %}
+    WHERE
+        block_timestamp_hour >= LEAST(
+            COALESCE(
+                '{{ min_block_timestamp_hour_blocks }}',
+                '2000-01-01'
+            ),
+            COALESCE(
+                '{{ min_block_timestamp_hour_txns }}',
+                '2000-01-01'
+            )
+        )
+    {% endif %}
+)
+SELECT
+    A.block_timestamp_hour,
+    A.block_id_min,
+    A.block_id_max,
+    A.block_count,
+    b.transaction_count,
+    b.transaction_count_success,
+    b.transaction_count_failed,
+    b.unique_from_count,
+    b.total_fees_native,
+    A.core_metrics_block_hourly_id AS ez_core_metrics_hourly_id,
+    GREATEST(
+        A.inserted_timestamp,
+        b.inserted_timestamp
+    ) AS inserted_timestamp,
+    GREATEST(
+        A.modified_timestamp,
+        b.modified_timestamp
+    ) AS modified_timestamp
+FROM
+    blocks A
+    JOIN txs b
+    ON A.block_timestamp_hour = b.block_timestamp_hour

--- a/models/gold/stats/stats__ez_core_metrics_hourly.yml
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.yml
@@ -71,14 +71,6 @@ models:
               column_type_list:
                 - NUMBER
                 - FLOAT
-      - name: UNIQUE_TO_COUNT
-        description: "Number of unique receivers in an hour."
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
       - name: TOTAL_FEES_NATIVE
         description: "Total fees in native currency for an hour."
         tests:

--- a/models/gold/stats/stats__ez_core_metrics_hourly.yml
+++ b/models/gold/stats/stats__ez_core_metrics_hourly.yml
@@ -1,0 +1,102 @@
+version: 2
+models:
+  - name: stats__ez_core_metrics_hourly
+    description: 'Hourly core metrics for the Aleo blockchain.'
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_TIMESTAMP_HOUR
+    columns:
+      - name: BLOCK_TIMESTAMP_HOUR
+        description: "Truncated timestamp of a block."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: BLOCK_ID_MIN
+        description: "Minimum block ID in an hour."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_ID_MAX
+        description: "Maximum block ID in an hour."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_COUNT
+        description: "Number of blocks in an hour."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TRANSACTION_COUNT
+        description: "Number of transactions in an hour."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TRANSACTION_COUNT_SUCCESS
+        description: "Number of successful transactions in an hour."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TRANSACTION_COUNT_FAILED
+        description: "Number of failed transactions in an hour."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: UNIQUE_FROM_COUNT
+        description: "Number of unique senders in an hour."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: UNIQUE_TO_COUNT
+        description: "Number of unique receivers in an hour."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOTAL_FEES_NATIVE
+        description: "Total fees in native currency for an hour."
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - DECIMAL
+                - FLOAT
+                - NUMBER
+      - name: TOTAL_FEES_USD
+        description: "Total fees in USD for an hour."
+      - name: EZ_CORE_METRICS_HOURLY_ID
+        description: '{{ doc("pk") }}'  
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/silver/core/_observability/silver_observability__blocks_completeness.sql
+++ b/models/silver/core/_observability/silver_observability__blocks_completeness.sql
@@ -1,0 +1,133 @@
+{{ config(
+    materialized = 'incremental',
+    full_refresh = false,
+    tags = ['recent_test']
+) }}
+
+WITH source AS (
+
+    SELECT
+        block_id,
+        block_timestamp,
+        LAG(
+            block_id,
+            1
+        ) over (
+            ORDER BY
+                block_id ASC
+        ) AS prev_BLOCK_ID
+    FROM
+        {{ ref('core__fact_blocks') }} A
+    WHERE
+        block_timestamp < DATEADD(
+            HOUR,
+            -24,
+            SYSDATE()
+        )
+
+{% if is_incremental() %}
+AND (
+    block_timestamp >= DATEADD(
+        HOUR,
+        -96,(
+            SELECT
+                MAX(
+                    max_block_timestamp
+                )
+            FROM
+                {{ this }}
+        )
+    )
+    OR ({% if var('OBSERV_FULL_TEST') %}
+        block_id >= 0
+    {% else %}
+        block_id >= (
+    SELECT
+        MIN(VALUE) - 1
+    FROM
+        (
+    SELECT
+        blocks_impacted_array
+    FROM
+        {{ this }}
+        qualify ROW_NUMBER() over (
+    ORDER BY
+        test_timestamp DESC) = 1), LATERAL FLATTEN(input => blocks_impacted_array))
+    {% endif %})
+)
+{% endif %}
+),
+block_gen AS (
+    SELECT
+        _id AS block_id
+    FROM
+        {{ source(
+            'crosschain_silver',
+            'number_sequence'
+        ) }}
+    WHERE
+        _id BETWEEN (
+            SELECT
+                MIN(block_id)
+            FROM
+                source
+        )
+        AND (
+            SELECT
+                MAX(block_id)
+            FROM
+                source
+        )
+)
+SELECT
+    'blocks' AS test_name,
+    MIN(
+        b.block_id
+    ) AS min_block,
+    MAX(
+        b.block_id
+    ) AS max_block,
+    MIN(
+        b.block_timestamp
+    ) AS min_block_timestamp,
+    MAX(
+        b.block_timestamp
+    ) AS max_block_timestamp,
+    COUNT(1) AS blocks_tested,
+    COUNT(
+        CASE
+            WHEN C.block_id IS NOT NULL THEN A.block_id
+        END
+    ) AS blocks_impacted_count,
+    ARRAY_AGG(
+        CASE
+            WHEN C.block_id IS NOT NULL THEN A.block_id
+        END
+    ) within GROUP (
+        ORDER BY
+            A.block_id
+    ) AS blocks_impacted_array,
+    ARRAY_AGG(
+        DISTINCT CASE
+            WHEN C.block_id IS NOT NULL THEN OBJECT_CONSTRUCT(
+                'prev_block_id',
+                C.prev_block_id,
+                'block_id',
+                C.block_id
+            )
+        END
+    ) AS test_failure_details,
+    SYSDATE() AS test_timestamp
+FROM
+    block_gen A
+    LEFT JOIN source b
+    ON A.block_id = b.block_id
+    LEFT JOIN source C
+    ON A.block_id > C.prev_BLOCK_ID
+    AND A.block_id < C.block_id
+    AND C.block_id - C.prev_BLOCK_ID <> 1
+WHERE
+    COALESCE(
+        b.block_id,
+        C.block_id
+    ) IS NOT NULL

--- a/models/silver/core/_observability/silver_observability__blocks_completeness.yml
+++ b/models/silver/core/_observability/silver_observability__blocks_completeness.yml
@@ -1,77 +1,75 @@
 version: 2
 models:
-  - name: silver_stats__core_metrics_hourly
+  - name: silver_observability__blocks_completeness
+    description: Records of all blocks block gaps (missing blocks) with a timestamp the test was run
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - BLOCK_TIMESTAMP_HOUR
+            - TEST_TIMESTAMP
     columns:
-      - name: BLOCK_TIMESTAMP_HOUR
+      - name: MIN_BLOCK
+        description: The lowest block id in the test
         tests:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
-                - TIMESTAMP_LTZ
+                - NUMBER
+      - name: MAX_BLOCK
+        description: The highest block id in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: MIN_BLOCK_TIMESTAMP
+        description: The lowest block timestamp in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
                 - TIMESTAMP_NTZ
-      - name: BLOCK_ID_MIN
+      - name: MAX_BLOCK_TIMESTAMP
+        description: The highest block timestamp in the test
         tests:
           - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: BLOCK_ID_MAX
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: BLOCK_COUNT
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: TRANSACTION_COUNT
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: TRANSACTION_COUNT_SUCCESS
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: TRANSACTION_COUNT_FAILED
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: UNIQUE_FROM_COUNT
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: TOTAL_FEES
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - DECIMAL
-                - FLOAT
-                - NUMBER
-      - name: _INSERTED_TIMESTAMP
-        tests:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 1
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: BLOCKS_TESTED
+        description: Count of blocks in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: BLOCKS_IMPACTED_COUNT
+        description: Count of block gaps in the test
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: BLOCKS_IMPACTED_ARRAY
+        description: Array of affected blocks
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - ARRAY
+      - name: TEST_FAILURE_DETAILS
+        description: Array of details of the failure
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - ARRAY
+      - name: TEST_TIMESTAMP
+        description: When the test was run
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ

--- a/models/silver/core/_observability/silver_observability__transactions_completeness.sql
+++ b/models/silver/core/_observability/silver_observability__transactions_completeness.sql
@@ -1,0 +1,211 @@
+{{ config(
+    materialized = 'incremental',
+    full_refresh = false,
+    tags = ['recent_test']
+) }}
+
+WITH rel_blocks AS (
+
+    SELECT
+        block_id,
+        block_timestamp
+    FROM
+        {{ ref('core__fact_blocks') }}
+    WHERE
+        block_timestamp < DATEADD(
+            HOUR,
+            -12,
+            SYSDATE()
+        )
+
+{% if is_incremental() %}
+AND (
+    block_timestamp >= DATEADD(
+        HOUR,
+        -72,(
+            SELECT
+                MAX(
+                    max_block_timestamp
+                )
+            FROM
+                {{ this }}
+        )
+    )
+    OR ({% if var('OBSERV_FULL_TEST') %}
+        block_id >= 0
+    {% else %}
+        block_id >= (
+    SELECT
+        MIN(VALUE) - 1
+    FROM
+        (
+    SELECT
+        blocks_impacted_array
+    FROM
+        {{ this }}
+        qualify ROW_NUMBER() over (
+    ORDER BY
+        test_timestamp DESC) = 1), LATERAL FLATTEN(input => blocks_impacted_array))
+    {% endif %})
+)
+{% endif %}
+),
+bronze AS (
+    SELECT
+        A.block_id,
+        b.block_timestamp,
+        A.tx_id
+    FROM
+        {{ ref('silver__transactions') }} A
+        JOIN rel_blocks b
+        ON A.block_id = b.block_id
+
+{% if is_incremental() %}
+WHERE
+    A.inserted_timestamp >= CURRENT_DATE - 14
+    OR {% if var('OBSERV_FULL_TEST') %}
+        1 = 1
+    {% else %}
+        (
+            SELECT
+                MIN(VALUE) - 1
+            FROM
+                (
+                    SELECT
+                        blocks_impacted_array
+                    FROM
+                        {{ this }}
+                        qualify ROW_NUMBER() over (
+                            ORDER BY
+                                test_timestamp DESC
+                        ) = 1
+                ),
+                LATERAL FLATTEN(
+                    input => blocks_impacted_array
+                )
+        ) IS NOT NULL
+    {% endif %}
+{% endif %}
+
+qualify(ROW_NUMBER() over (PARTITION BY tx_id
+ORDER BY
+    status DESC, A.block_id DESC, A.inserted_timestamp DESC)) = 1
+),
+bronze_count AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        COUNT(
+            DISTINCT tx_id
+        ) AS tx_count
+    FROM
+        bronze
+    GROUP BY
+        block_id,
+        block_timestamp
+),
+bronze_min AS (
+    SELECT
+        MIN(block_id) block_id
+    FROM
+        bronze
+),
+bronze_node AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_count
+    FROM
+        {{ ref('silver__blocks') }}
+    WHERE
+        block_timestamp BETWEEN (
+            SELECT
+                MIN(block_timestamp)
+            FROM
+                rel_blocks
+        )
+        AND (
+            SELECT
+                MAX(block_timestamp)
+            FROM
+                rel_blocks
+        )
+)
+SELECT
+    'transactions' AS test_name,
+    MIN(
+        A.block_id
+    ) AS min_block,
+    MAX(
+        A.block_id
+    ) AS max_block,
+    MIN(
+        A.block_timestamp
+    ) AS min_block_timestamp,
+    MAX(
+        A.block_timestamp
+    ) AS max_block_timestamp,
+    COUNT(1) AS blocks_tested,
+    SUM(
+        CASE
+            WHEN COALESCE(
+                b.tx_count,
+                0
+            ) - A.tx_count <> 0 THEN 1
+            ELSE 0
+        END
+    ) AS blocks_impacted_count,
+    ARRAY_AGG(
+        CASE
+            WHEN COALESCE(
+                b.tx_count,
+                0
+            ) - A.tx_count <> 0 THEN A.block_id
+        END
+    ) within GROUP (
+        ORDER BY
+            A.block_id
+    ) AS blocks_impacted_array,
+    SUM(
+        ABS(
+            COALESCE(
+                b.tx_count,
+                0
+            ) - A.tx_count
+        )
+    ) AS transactions_impacted_count,
+    ARRAY_AGG(
+        CASE
+            WHEN COALESCE(
+                b.tx_count,
+                0
+            ) - A.tx_count <> 0 THEN OBJECT_CONSTRUCT(
+                'block',
+                A.block_id,
+                'block_timestamp',
+                A.block_timestamp,
+                'diff',
+                COALESCE(
+                    b.tx_count,
+                    0
+                ) - A.tx_count,
+                'blockchain_num_txs',
+                A.tx_count,
+                'bronze_num_txs',
+                COALESCE(
+                    b.tx_count,
+                    0
+                )
+            )
+        END
+    ) within GROUP(
+        ORDER BY
+            A.block_id
+    ) AS test_failure_details,
+    SYSDATE() AS test_timestamp
+FROM
+    bronze_node A
+    JOIN bronze_min bm
+    ON A.block_id >= bm.block_id
+    LEFT JOIN bronze_count b
+    ON A.block_id = b.block_id

--- a/models/silver/core/_observability/silver_observability__transactions_completeness.yml
+++ b/models/silver/core/_observability/silver_observability__transactions_completeness.yml
@@ -1,0 +1,82 @@
+version: 2
+models:
+  - name: silver_observability__transactions_completeness
+    description: Records of all blocks with missing transactions with a timestamp the test was run
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TEST_TIMESTAMP
+    columns:
+      - name: MIN_BLOCK
+        description: The lowest block id in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: MAX_BLOCK
+        description: The highest block id in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: MIN_BLOCK_TIMESTAMP
+        description: The lowest block timestamp in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: MAX_BLOCK_TIMESTAMP
+        description: The highest block timestamp in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: BLOCKS_TESTED
+        description: Count of blocks in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: BLOCKS_IMPACTED_COUNT
+        description: Count of blocks with missing transactions in the test
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: BLOCKS_IMPACTED_ARRAY
+        description: Array of affected blocks
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - ARRAY
+      - name: TRANSACTIONS_IMPACTED_COUNT
+        description: Total count of missing transactions in the test
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: TEST_FAILURE_DETAILS
+        description: blocks with missing transactions with the number of missing transactions
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - ARRAY
+      - name: TEST_TIMESTAMP
+        description: When the test was run
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ

--- a/models/silver/core/_observability/silver_observability__transitions_completeness.sql
+++ b/models/silver/core/_observability/silver_observability__transitions_completeness.sql
@@ -1,0 +1,214 @@
+{{ config(
+    materialized = 'incremental',
+    full_refresh = false,
+    tags = ['recent_test']
+) }}
+
+WITH rel_blocks AS (
+
+    SELECT
+        block_id,
+        block_timestamp
+    FROM
+        {{ ref('core__fact_blocks') }}
+    WHERE
+        block_timestamp < DATEADD(
+            HOUR,
+            -12,
+            SYSDATE()
+        )
+
+    {% if is_incremental() %}
+    AND (
+        block_timestamp >= DATEADD(
+            HOUR,
+            -72,(
+                SELECT
+                    MAX(
+                        max_block_timestamp
+                    )
+                FROM
+                    {{ this }}
+            )
+        )
+        OR ({% if var('OBSERV_FULL_TEST') %}
+            block_id >= 0
+        {% else %}
+            block_id >= (
+        SELECT
+            MIN(VALUE) - 1
+        FROM
+            (
+        SELECT
+            blocks_impacted_array
+        FROM
+            {{ this }}
+            qualify ROW_NUMBER() over (
+        ORDER BY
+            test_timestamp DESC) = 1), LATERAL FLATTEN(input => blocks_impacted_array))
+        {% endif %})
+    )
+    {% endif %}
+),
+bronze AS (
+    SELECT
+        A.block_id,
+        b.block_timestamp,
+        A.tx_id,
+        A.transition_id
+    FROM
+        {{ ref('silver__transitions') }} A
+        JOIN rel_blocks b
+        ON A.block_id = b.block_id
+
+    {% if is_incremental() %}
+    WHERE
+        A.inserted_timestamp >= CURRENT_DATE - 14
+        OR {% if var('OBSERV_FULL_TEST') %}
+            1 = 1
+        {% else %}
+            (
+                SELECT
+                    MIN(VALUE) - 1
+                FROM
+                    (
+                        SELECT
+                            blocks_impacted_array
+                        FROM
+                            {{ this }}
+                            qualify ROW_NUMBER() over (
+                                ORDER BY
+                                    test_timestamp DESC
+                            ) = 1
+                    ),
+                    LATERAL FLATTEN(
+                        input => blocks_impacted_array
+                    )
+            ) IS NOT NULL
+        {% endif %}
+    {% endif %}
+
+    qualify(ROW_NUMBER() over (PARTITION BY tx_id,transition_id
+    ORDER BY
+        succeeded DESC, A.block_id DESC, A.tx_id DESC, A.inserted_timestamp DESC)) = 1
+),
+bronze_count AS (
+    SELECT
+        block_id,
+        tx_id,
+        block_timestamp,
+        COUNT(
+            DISTINCT transition_id
+        ) AS transition_count
+    FROM
+        bronze
+    GROUP BY
+        ALL
+),
+bronze_min AS (
+    SELECT
+        MIN(block_id) block_id
+    FROM
+        bronze
+),
+bronze_node AS (
+    SELECT
+        block_id,
+        tx_id,
+        block_timestamp,
+        transition_count
+    FROM
+        {{ ref('silver__transactions') }}
+    WHERE
+        block_timestamp BETWEEN (
+            SELECT
+                MIN(block_timestamp)
+            FROM
+                rel_blocks
+        )
+        AND (
+            SELECT
+                MAX(block_timestamp)
+            FROM
+                rel_blocks
+        )
+)
+SELECT
+    'transitions' AS test_name,
+    MIN(
+        A.block_id
+    ) AS min_block,
+    MAX(
+        A.block_id
+    ) AS max_block,
+    MIN(
+        A.block_timestamp
+    ) AS min_block_timestamp,
+    MAX(
+        A.block_timestamp
+    ) AS max_block_timestamp,
+    COUNT(1) AS blocks_tested,
+    SUM(
+        CASE
+            WHEN COALESCE(
+                b.transition_count,
+                0
+            ) - A.transition_count <> 0 THEN 1
+            ELSE 0
+        END
+    ) AS blocks_impacted_count,
+    ARRAY_AGG(
+        CASE
+            WHEN COALESCE(
+                b.transition_count,
+                0
+            ) - A.transition_count <> 0 THEN A.block_id
+        END
+    ) within GROUP (
+        ORDER BY
+            A.block_id
+    ) AS blocks_impacted_array,
+    SUM(
+        ABS(
+            COALESCE(
+                b.transition_count,
+                0
+            ) - A.transition_count
+        )
+    ) AS transitions_impacted_count,
+    ARRAY_AGG(
+        CASE
+            WHEN COALESCE(
+                b.transition_count,
+                0
+            ) - A.transition_count <> 0 THEN OBJECT_CONSTRUCT(
+                'block',
+                A.block_id,
+                'block_timestamp',
+                A.block_timestamp,
+                'diff',
+                COALESCE(
+                    b.transition_count,
+                    0
+                ) - A.transition_count,
+                'blockchain_num_transitions',
+                A.transition_count,
+                'bronze_num_transitions',
+                COALESCE(
+                    b.transition_count,
+                    0
+                )
+            )
+        END
+    ) within GROUP(
+        ORDER BY
+            A.block_id
+    ) AS test_failure_details,
+    SYSDATE() AS test_timestamp
+FROM
+    bronze_node A
+    JOIN bronze_min bm
+    ON A.block_id >= bm.block_id
+    LEFT JOIN bronze_count b
+    ON A.block_id = b.block_id
+    AND A.tx_id = b.tx_id

--- a/models/silver/core/_observability/silver_observability__transitions_completeness.yml
+++ b/models/silver/core/_observability/silver_observability__transitions_completeness.yml
@@ -1,0 +1,82 @@
+version: 2
+models:
+  - name: silver_observability__transitions_completeness
+    description: Records of all blocks with missing transitions with a timestamp the test was run
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TEST_TIMESTAMP
+    columns:
+      - name: MIN_BLOCK
+        description: The lowest block id in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: MAX_BLOCK
+        description: The highest block id in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: MIN_BLOCK_TIMESTAMP
+        description: The lowest block timestamp in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: MAX_BLOCK_TIMESTAMP
+        description: The highest block timestamp in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: BLOCKS_TESTED
+        description: Count of blocks in the test
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: BLOCKS_IMPACTED_COUNT
+        description: Count of blocks with missing transitions in the test
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: BLOCKS_IMPACTED_ARRAY
+        description: Array of affected blocks
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - ARRAY
+      - name: TRANSITIONS_IMPACTED_COUNT
+        description: Total count of missing transitions in the test
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+      - name: TEST_FAILURE_DETAILS
+        description: blocks with missing transitions with the number of missing transitions
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - ARRAY
+      - name: TEST_TIMESTAMP
+        description: When the test was run
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -122,7 +122,6 @@ select
     tx_id,
     transition_id,
     index,
-    program_id as token_address,
     succeeded as tx_succeeded,
     function as transfer_type,
     transfer_from as sender,
@@ -131,6 +130,8 @@ select
             10,
             6
         ) AS amount,
+    TRUE AS is_native,
+    NULL AS token_address,
     SYSDATE() as inserted_timestamp,
     SYSDATE() as modified_timestamp,
     '{{ invocation_id }}' as _invocation_id

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -1,0 +1,127 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_predicates = ["COALESCE(DBT_INTERNAL_DEST.block_timestamp::DATE,'2099-12-31') >= (select min(block_timestamp::DATE) from " ~ generate_tmp_view_name(this) ~ ")"],
+    unique_key = ['transition_id'],
+    incremental_strategy = 'merge',
+    merge_exclude_columns = ['inserted_timestamp'],
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['core', 'recent_test']
+) }}
+
+WITH base AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        transition_id,
+        outputs,
+        function,
+        succeeded,
+        inserted_timestamp,
+        modified_timestamp,
+        invocation_id
+    FROM
+        {{ ref('silver__transitions') }}
+    WHERE
+        program_id = 'credits.aleo'
+        AND function IN (
+            'transfer_public',
+            'transfer_private',
+            'transfer_public_as_signer',
+            'transfer_private_to_public',
+            'transfer_public_to_private'
+        )
+),
+output_args AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        transition_id,
+        function,
+        succeeded,
+        REGEXP_SUBSTR(
+            outputs[array_size(outputs)-1] :value :: STRING,
+            'arguments:\\s*\\[(.*?)\\]',
+            1,
+            1,
+            'sie'
+        ) as args_string,
+        inserted_timestamp,
+        modified_timestamp,
+        invocation_id
+    FROM
+        base
+),
+output_args_cleaned AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        transition_id,
+        function,
+        succeeded,
+        SPLIT(
+            REGEXP_REPLACE(
+                REGEXP_REPLACE(
+                    REGEXP_REPLACE(args_string, '\\s+', ''),
+                    '\\[|\\]',
+                    ''
+                ),
+                'u64$',
+                ''
+            ),
+            ','
+        ) as args_array,
+        inserted_timestamp,
+        modified_timestamp,
+        invocation_id
+    FROM output_args
+),
+mapped_transfers AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        transition_id,
+        succeeded,
+        function,
+        CASE
+            WHEN function IN ('transfer_public', 'transfer_public_as_signer') THEN args_array[0]
+            WHEN function = 'transfer_private_to_public' THEN null
+            WHEN function = 'transfer_public_to_private' THEN args_array[0]
+            WHEN function = 'transfer_private' THEN null
+        END :: STRING as transfer_from,
+        CASE
+            WHEN function IN ('transfer_public', 'transfer_public_as_signer') THEN args_array[1]
+            WHEN function = 'transfer_private_to_public' THEN args_array[0]
+            WHEN function = 'transfer_public_to_private' THEN null
+            WHEN function = 'transfer_private' THEN null
+        END :: STRING as transfer_to,
+        CASE
+            WHEN function IN ('transfer_public', 'transfer_public_as_signer') THEN args_array[2]
+            WHEN function = 'transfer_private_to_public' THEN args_array[1]
+            WHEN function = 'transfer_public_to_private' THEN args_array[1]
+            WHEN function = 'transfer_private' THEN null
+        END :: STRING as amount,
+        inserted_timestamp,
+        modified_timestamp,
+        invocation_id
+    FROM output_args_cleaned
+)
+select
+    block_id,
+    block_timestamp,
+    tx_id,
+    transition_id,
+    succeeded as tx_succeeded,
+    function as transfer_type,
+    transfer_from as sender,
+    transfer_to as receiver,
+    REPLACE(amount, 'u64', '') :: INT as amount,
+    'aleo_credits' as currency,
+    inserted_timestamp,
+    modified_timestamp,
+    invocation_id
+from 
+    mapped_transfers

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -69,7 +69,7 @@ output_args_cleaned AS (
         tx_id,
         transition_id,
         index,
-        program_id
+        program_id,
         function,
         succeeded,
         SPLIT(
@@ -122,7 +122,7 @@ select
     tx_id,
     transition_id,
     index,
-    program_id,
+    program_id as token_address,
     succeeded as tx_succeeded,
     function as transfer_type,
     transfer_from as sender,

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -31,6 +31,17 @@ WITH base AS (
             'transfer_private_to_public',
             'transfer_public_to_private'
         )
+    {% if is_incremental() %}
+    AND modified_timestamp >= DATEADD(
+        MINUTE,
+        -5,(
+            SELECT
+                MAX(modified_timestamp)
+            FROM
+                {{ this }}
+            )
+        )
+    {% endif %}
 ),
 output_args AS (
     SELECT
@@ -118,7 +129,10 @@ select
     function as transfer_type,
     transfer_from as sender,
     transfer_to as receiver,
-    REPLACE(amount, 'u64', '') :: INT as amount,
+    REPLACE(amount, 'u64', '') :: BIGINT / pow(
+            10,
+            6
+        ) AS amount,
     'aleo_credits' as currency,
     inserted_timestamp,
     modified_timestamp,

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -4,7 +4,7 @@
     unique_key = ['transition_id'],
     incremental_strategy = 'merge',
     merge_exclude_columns = ['inserted_timestamp'],
-    cluster_by = ['modified_timestamp::DATE'],
+    cluster_by = ['block_timestamp::DATE'],
     tags = ['noncore', 'full_test']
 ) }}
 

--- a/models/silver/core/silver__native_transfers.yml
+++ b/models/silver/core/silver__native_transfers.yml
@@ -49,14 +49,6 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: NUMBER
-      - name: PROGRAM_ID
-        description: "{{ doc('program_id') }}"
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
       - name: TX_SUCCEEDED
         tests:
           - not_null

--- a/models/silver/core/silver__native_transfers.yml
+++ b/models/silver/core/silver__native_transfers.yml
@@ -5,9 +5,7 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - TX_ID
             - TRANSITION_ID
-            - INDEX
     columns:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"

--- a/models/silver/core/silver__native_transfers.yml
+++ b/models/silver/core/silver__native_transfers.yml
@@ -7,7 +7,7 @@ models:
           combination_of_columns:
             - TX_ID
             - TRANSITION_ID
-            - CURRENCY
+            - INDEX
     columns:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"
@@ -17,7 +17,6 @@ models:
               column_type_list:
                 - NUMBER    
                 - FLOAT  
-
       - name: BLOCK_TIMESTAMP
         description: "{{ doc('block_timestamp') }}"
         tests:
@@ -45,6 +44,19 @@ models:
               column_type_list:
                 - STRING
                 - VARCHAR
+      - name: INDEX
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: NUMBER
+      - name: PROGRAM_ID
+        description: "{{ doc('program_id') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
       - name: TX_SUCCEEDED
         tests:
           - not_null
@@ -60,7 +72,7 @@ models:
                 - STRING
                 - VARCHAR
       - name: SENDER
-        description: "Address that tokens are transferred from."
+        description: "Address that tokens are transferred from. If null, the sender is private and unresolvable."
         tests: 
           - not_null:
               where: transfer_type IN ('transfer_public', 'transfer_public_as_signer', 'transfer_public_to_private')
@@ -69,7 +81,7 @@ models:
                 - STRING
                 - VARCHAR
       - name: RECEIVER
-        description: "Address that tokens are transferred to."
+        description: "Address that tokens are transferred to. If null, the receiver is private and unresolvable."
         tests: 
           - not_null:
               where: transfer_type IN ('transfer_public', 'transfer_public_as_signer', 'transfer_private_to_public')
@@ -78,7 +90,7 @@ models:
                 - STRING
                 - VARCHAR
       - name: AMOUNT
-        description: "Number of tokens transferred."
+        description: "Number of tokens transferred. If null, the amount is private and unresolvable."
         tests: 
           - not_null:
               where: transfer_type != 'transfer_private'
@@ -86,11 +98,3 @@ models:
               column_type_list:
                 - NUMBER    
                 - FLOAT 
-      - name: CURRENCY
-        description: "Currency of the transfer."
-        tests: 
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR

--- a/models/silver/core/silver__native_transfers.yml
+++ b/models/silver/core/silver__native_transfers.yml
@@ -1,0 +1,96 @@
+version: 2
+models:
+  - name: silver__native_transfers
+    description: Records of native token transfers on Aleo between wallets
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TX_ID
+            - TRANSITION_ID
+            - CURRENCY
+    columns:
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT  
+
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: inserted_timestamp < dateadd('hour', -1, SYSDATE())
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TRANSITION_ID
+        description: "{{ doc('transition_id') }}"
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TX_SUCCEEDED
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - BOOLEAN
+      - name: TRANSFER_TYPE
+        description: "{{ doc('transfer_type') }}"
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SENDER
+        description: "Address that tokens are transferred from."
+        tests: 
+          - not_null:
+              where: transfer_type IN ('transfer_public', 'transfer_public_as_signer', 'transfer_public_to_private')
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: RECEIVER
+        description: "Address that tokens are transferred to."
+        tests: 
+          - not_null:
+              where: transfer_type IN ('transfer_public', 'transfer_public_as_signer', 'transfer_private_to_public')
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: AMOUNT
+        description: "Number of tokens transferred."
+        tests: 
+          - not_null:
+              where: transfer_type != 'transfer_private'
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT 
+      - name: CURRENCY
+        description: "Currency of the transfer."
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR

--- a/models/silver/core/silver__programs.sql
+++ b/models/silver/core/silver__programs.sql
@@ -11,14 +11,7 @@ WITH base AS (
     SELECT
         block_id,
         block_timestamp,
-        REGEXP_SUBSTR(
-            deployment_msg :program :: STRING,
-            'program\\s+(\\S+);',
-            1,
-            1,
-            'e',
-            1
-        ) AS program_id,
+        program_id,
         deployment_msg
     FROM
         {{ ref('silver__transactions') }}

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -67,6 +67,14 @@ SELECT
     fee_msg,
     execution_msg,
     deployment_msg,
+    REGEXP_SUBSTR(
+        deployment_msg :program :: STRING,
+        'program\\s+(\\S+);',
+        1,
+        1,
+        'e',
+        1
+    ) AS program_id,
     owner_msg,
     finalize_msg,
     rejected_msg,

--- a/models/silver/core/silver__transitions_fee.yml
+++ b/models/silver/core/silver__transitions_fee.yml
@@ -3,6 +3,12 @@ version: 2
 models:
   - name: silver__transitions_fee
     description: "This model contains detailed information about fee transitions within transactions on the Aleo blockchain."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_ID
+            - TX_ID
+            - TRANSITION_ID
     columns:
       - name: BLOCK_ID
         description: "{{ doc('block_id') }}"

--- a/models/silver/stats/silver_stats__core_metrics_block_hourly.sql
+++ b/models/silver/stats/silver_stats__core_metrics_block_hourly.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'view',
-    tags = ['noncore','recent_test']
+    tags = ['noncore']
 ) }}
 
 SELECT

--- a/models/silver/stats/silver_stats__core_metrics_block_hourly.sql
+++ b/models/silver/stats/silver_stats__core_metrics_block_hourly.sql
@@ -1,0 +1,27 @@
+{{ config(
+    materialized = 'view',
+    tags = ['noncore','recent_test']
+) }}
+
+SELECT
+    DATE_TRUNC(
+        'hour',
+        block_timestamp
+    ) AS block_timestamp_hour,
+    MIN(block_id) AS block_id_min,
+    MAX(block_id) AS block_id_max,
+    COUNT(
+        1
+    ) AS block_count,
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_timestamp_hour']
+    ) }} AS core_metrics_block_hourly_id,
+    MAX(inserted_timestamp) AS inserted_timestamp,
+    MAX(modified_timestamp) AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    {{ ref('core__fact_blocks') }}
+WHERE
+    block_timestamp_hour < DATE_TRUNC('hour', SYSDATE())
+GROUP BY
+    1

--- a/models/silver/stats/silver_stats__core_metrics_block_hourly.yml
+++ b/models/silver/stats/silver_stats__core_metrics_block_hourly.yml
@@ -1,0 +1,9 @@
+version: 2
+models:
+  - name: silver_stats__core_metrics_block_hourly
+    columns:
+      - name: BLOCK_TIMESTAMP_HOUR
+      - name: BLOCK_ID_MIN
+      - name: BLOCK_ID_MAX
+      - name: BLOCK_COUNT
+      - name: INSERTED_TIMESTAMP

--- a/models/silver/stats/silver_stats__core_metrics_hourly.sql
+++ b/models/silver/stats/silver_stats__core_metrics_hourly.sql
@@ -45,11 +45,8 @@ SELECT
         END
     ) AS transaction_count_failed,
     COUNT(
-        DISTINCT tf.sender
+        DISTINCT f.fee_payer
     ) AS unique_from_count,
-    COUNT(
-        DISTINCT tf.receiver
-    ) AS unique_to_count,
     SUM(f.fee) AS total_fees,
     MAX(ts.inserted_timestamp) AS _inserted_timestamp,  
     {{ dbt_utils.generate_surrogate_key(

--- a/models/silver/stats/silver_stats__core_metrics_hourly.sql
+++ b/models/silver/stats/silver_stats__core_metrics_hourly.sql
@@ -1,28 +1,8 @@
 
 {{ config(
     materialized = 'view',
-    tags = ['noncore','recent_test']
+    tags = ['noncore']
 ) }}
-/* run incremental timestamp value first then use it as a static value */
-{% if execute %}
-
-{% if is_incremental() %}
-{% set query %}
-
-SELECT
-    MIN(DATE_TRUNC('hour', block_timestamp)) block_timestamp_hour
-FROM
-    {{ ref('core__fact_transactions') }}
-WHERE
-    inserted_timestamp >= (
-        SELECT
-            MAX(inserted_timestamp)
-        FROM
-            {{ this }}
-    ) {% endset %}
-    {% set min_block_timestamp_hour = run_query(query).columns [0].values() [0] %}
-{% endif %}
-{% endif %}
 SELECT
     DATE_TRUNC('hour', block_timestamp) AS block_timestamp_hour,
     COUNT(
@@ -56,11 +36,5 @@ WHERE
         'hour',
         CURRENT_TIMESTAMP
     )
-{% if is_incremental() %}
-AND DATE_TRUNC(
-    'hour',
-    ts.block_timestamp
-) >= '{{ min_block_timestamp_hour }}'
-{% endif %}
 GROUP BY
     1

--- a/models/silver/stats/silver_stats__core_metrics_hourly.sql
+++ b/models/silver/stats/silver_stats__core_metrics_hourly.sql
@@ -45,9 +45,9 @@ SELECT
         END
     ) AS transaction_count_failed,
     COUNT(
-        DISTINCT f.fee_payer
+        DISTINCT ts.fee_payer
     ) AS unique_from_count,
-    SUM(f.fee) AS total_fees,
+    SUM(ts.fee) AS total_fees,
     MAX(ts.inserted_timestamp) AS _inserted_timestamp,  
     {{ dbt_utils.generate_surrogate_key(
         ['block_timestamp_hour']
@@ -57,12 +57,9 @@ SELECT
     '{{ invocation_id }}' AS _invocation_id
 
 FROM
-    {{ ref('silver__transitions') }} ts
+    {{ ref('silver__transitions_fee') }} ts
 JOIN
     {{ref ('silver__native_transfers')}} tf
-    USING(tx_id)
-JOIN
-    {{ ref('silver__transitions_fee') }} f
     USING(tx_id)
 WHERE
     DATE_TRUNC('hour', ts.block_timestamp) < DATE_TRUNC(

--- a/models/silver/stats/silver_stats__core_metrics_hourly.sql
+++ b/models/silver/stats/silver_stats__core_metrics_hourly.sql
@@ -1,0 +1,82 @@
+
+{{ config(
+    materialized = 'view',
+    tags = ['noncore','recent_test']
+) }}
+/* run incremental timestamp value first then use it as a static value */
+{% if execute %}
+
+{% if is_incremental() %}
+{% set query %}
+
+SELECT
+    MIN(DATE_TRUNC('hour', block_timestamp)) block_timestamp_hour
+FROM
+    {{ ref('silver__transitions') }}
+WHERE
+    inserted_timestamp >= (
+        SELECT
+            MAX(inserted_timestamp)
+        FROM
+            {{ this }}
+    ) {% endset %}
+    {% set min_block_timestamp_hour = run_query(query).columns [0].values() [0] %}
+{% endif %}
+{% endif %}
+
+SELECT
+    DATE_TRUNC('hour', ts.block_timestamp) AS block_timestamp_hour,
+    MIN(block_id) AS block_id_min,
+    MAX(block_id) AS block_id_max,
+    COUNT(
+        DISTINCT block_id
+    ) AS block_count,
+    COUNT(
+        DISTINCT tx_id
+    ) AS transaction_count,
+    COUNT(
+        DISTINCT CASE
+            WHEN succeeded THEN tx_id
+        END
+    ) AS transaction_count_success,
+    COUNT(
+        DISTINCT CASE
+            WHEN NOT succeeded THEN tx_id
+        END
+    ) AS transaction_count_failed,
+    COUNT(
+        DISTINCT tf.sender
+    ) AS unique_from_count,
+    COUNT(
+        DISTINCT tf.receiver
+    ) AS unique_to_count,
+    SUM(f.fee) AS total_fees,
+    MAX(ts.inserted_timestamp) AS _inserted_timestamp,  
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_timestamp_hour']
+    ) }} AS core_metrics_hourly_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+
+FROM
+    {{ ref('silver__transitions') }} ts
+JOIN
+    {{ref ('silver__native_transfers')}} tf
+    USING(tx_id)
+JOIN
+    {{ ref('silver__transitions_fee') }} f
+    USING(tx_id)
+WHERE
+    DATE_TRUNC('hour', ts.block_timestamp) < DATE_TRUNC(
+        'hour',
+        CURRENT_TIMESTAMP
+    )
+{% if is_incremental() %}
+AND DATE_TRUNC(
+    'hour',
+    ts.block_timestamp
+) >= '{{ min_block_timestamp_hour }}'
+{% endif %}
+GROUP BY
+    1

--- a/models/silver/stats/silver_stats__core_metrics_hourly.sql
+++ b/models/silver/stats/silver_stats__core_metrics_hourly.sql
@@ -12,7 +12,7 @@
 SELECT
     MIN(DATE_TRUNC('hour', block_timestamp)) block_timestamp_hour
 FROM
-    {{ ref('silver__transitions') }}
+    {{ ref('core__fact_transactions') }}
 WHERE
     inserted_timestamp >= (
         SELECT
@@ -23,32 +23,26 @@ WHERE
     {% set min_block_timestamp_hour = run_query(query).columns [0].values() [0] %}
 {% endif %}
 {% endif %}
-
 SELECT
-    DATE_TRUNC('hour', ts.block_timestamp) AS block_timestamp_hour,
-    MIN(block_id) AS block_id_min,
-    MAX(block_id) AS block_id_max,
-    COUNT(
-        DISTINCT block_id
-    ) AS block_count,
+    DATE_TRUNC('hour', block_timestamp) AS block_timestamp_hour,
     COUNT(
         DISTINCT tx_id
     ) AS transaction_count,
     COUNT(
         DISTINCT CASE
-            WHEN succeeded THEN tx_id
+            WHEN tx_succeeded THEN tx_id
         END
     ) AS transaction_count_success,
     COUNT(
         DISTINCT CASE
-            WHEN NOT succeeded THEN tx_id
+            WHEN NOT tx_succeeded THEN tx_id
         END
     ) AS transaction_count_failed,
     COUNT(
-        DISTINCT ts.fee_payer
+        DISTINCT fee_payer
     ) AS unique_from_count,
-    SUM(ts.fee) AS total_fees,
-    MAX(ts.inserted_timestamp) AS _inserted_timestamp,  
+    SUM(fee) AS total_fees,
+    MAX(inserted_timestamp) AS _inserted_timestamp,  
     {{ dbt_utils.generate_surrogate_key(
         ['block_timestamp_hour']
     ) }} AS core_metrics_hourly_id,
@@ -56,9 +50,9 @@ SELECT
     SYSDATE() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id
 FROM
-    {{ ref('silver__transitions_fee') }} ts
+    {{ ref('core__fact_transactions') }} ts
 WHERE
-    DATE_TRUNC('hour', ts.block_timestamp) < DATE_TRUNC(
+    DATE_TRUNC('hour', block_timestamp) < DATE_TRUNC(
         'hour',
         CURRENT_TIMESTAMP
     )

--- a/models/silver/stats/silver_stats__core_metrics_hourly.sql
+++ b/models/silver/stats/silver_stats__core_metrics_hourly.sql
@@ -55,12 +55,8 @@ SELECT
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id
-
 FROM
     {{ ref('silver__transitions_fee') }} ts
-JOIN
-    {{ref ('silver__native_transfers')}} tf
-    USING(tx_id)
 WHERE
     DATE_TRUNC('hour', ts.block_timestamp) < DATE_TRUNC(
         'hour',

--- a/models/silver/stats/silver_stats__core_metrics_hourly.yml
+++ b/models/silver/stats/silver_stats__core_metrics_hourly.yml
@@ -13,27 +13,6 @@ models:
               column_type_list:
                 - TIMESTAMP_LTZ
                 - TIMESTAMP_NTZ
-      - name: BLOCK_ID_MIN
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: BLOCK_ID_MAX
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: BLOCK_COUNT
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
       - name: TRANSACTION_COUNT
         tests:
           - not_null

--- a/models/silver/stats/silver_stats__core_metrics_hourly.yml
+++ b/models/silver/stats/silver_stats__core_metrics_hourly.yml
@@ -1,0 +1,84 @@
+version: 2
+models:
+  - name: silver_stats__core_metrics_hourly
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_TIMESTAMP_HOUR
+    columns:
+      - name: BLOCK_TIMESTAMP_HOUR
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: BLOCK_ID_MIN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_ID_MAX
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_COUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TRANSACTION_COUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TRANSACTION_COUNT_SUCCESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TRANSACTION_COUNT_FAILED
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: UNIQUE_FROM_COUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: UNIQUE_TO_COUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOTAL_FEES
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - DECIMAL
+                - FLOAT
+                - NUMBER
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1

--- a/python/dbt_test_alert.py
+++ b/python/dbt_test_alert.py
@@ -1,0 +1,127 @@
+import datetime
+import requests
+import json
+import sys
+import os
+
+
+def log_test_result():
+    """Reads the run_results.json file and returns a dictionary of targeted test results"""
+
+    filepath = "target/run_results.json"
+
+    with open(filepath) as f:
+        run = json.load(f)
+
+    logs = []
+    messages = {
+        "fail": [],
+        "warn": []
+    }
+    test_count = 0
+    warn_count = 0
+    fail_count = 0
+
+    for test in run["results"]:
+        test_count += 1
+        if test["status"] != "pass":
+            logs.append(test)
+
+            message = f"{test['failures']} record failure(s) in {test['unique_id']}"
+
+            if test["status"] == "warn":
+                messages["warn"].append(message)
+                warn_count += 1
+            elif test["status"] == "fail":
+                messages["fail"].append(message)
+                fail_count += 1
+
+    dbt_test_result = {
+        "logs": logs,
+        "messages": messages,
+        "test_count": test_count,
+        "warn_count": warn_count,
+        "fail_count": fail_count,
+        "elapsed_time": str(datetime.timedelta(seconds=run["elapsed_time"]))
+    }
+
+    return dbt_test_result
+
+
+def create_message(**kwargs):
+    messageBody = {
+        "text": f"Hey{' <!here>' if len(kwargs['messages']['fail']) > 0 else ''}, new DBT test results for :{os.environ.get('DATABASE').split('_DEV')[0]}: {os.environ.get('DATABASE')}",
+        "attachments": [
+            {
+                "color": kwargs["color"],
+                "fields": [
+                    {
+                        "title": "Total Tests Run",
+                        "value": kwargs["test_count"],
+                        "short": True
+                    },
+                    {
+                        "title": "Total Time Elapsed",
+                        "value": kwargs["elapsed_time"],
+                        "short": True
+                    },
+                    {
+                        "title": "Number of Unsuccessful Tests",
+                        "value": f"Fail: {kwargs['fail_count']}, Warn: {kwargs['warn_count']}",
+                        "short": True
+                    },
+                    {
+                        "title": "Failed Tests:",
+                        "value": "\n".join(kwargs["messages"]["fail"]) if len(kwargs["messages"]["fail"]) > 0 else "None :)",
+                        "short": False
+                    }
+                ],
+                "actions": [
+
+                    {
+                        "type": "button",
+                        "text": "View Warnings",
+                        "style": "primary",
+                        "url": "https://github.com/FlipsideCrypto/aleo-models/actions/workflows/dbt_test_recent.yml",
+                        "confirm": {
+                            "title": f"{kwargs['warn_count']} Warnings",
+                            "text": "\n".join(kwargs["messages"]["warn"]) if len(kwargs["messages"]["warn"]) > 0 else "None :)",
+                            "ok_text": "Continue to GHA",
+                            "dismiss_text": "Dismiss"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+    return messageBody
+
+
+def send_alert(webhook_url):
+    """Sends a message to a slack channel"""
+
+    url = webhook_url
+
+    data = log_test_result()
+
+    send_message = create_message(
+        fail_count=data["fail_count"],
+        warn_count=data["warn_count"],
+        test_count=data["test_count"],
+        messages=data["messages"],
+        elapsed_time=data["elapsed_time"],
+        color="#f44336" if data["fail_count"] > 0 else "#4CAF50"
+    )
+
+    x = requests.post(url, json=send_message)
+
+    # test config to continue on error in workflow, so we want to exit with a non-zero code if there are any failures
+    if data['fail_count'] > 0:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
+    send_alert(webhook_url)


### PR DESCRIPTION
This PR introduces:
- 2 new curated models, docs, and tests for native Aleo transfers (silver and gold)
- 2 new stats models, docs, and tests (silver and gold)
- 1 noncore GHA workflow
- 1 updated docfile
- 1 updated test alerts script (`./python/dbt_test_alert.py`) that Jack uses but could switch to datadog

## Why curation was needed for stats
While building the stats models I needed transfers data... these would produce the `unique_from_count` and `unique_to_count` metrics. Aleoscan displays transfer info (I think we chatted about this in Kansas City), so I hoped for a new API endpoint:

![image](https://github.com/user-attachments/assets/686d1b60-3315-4cd7-84f4-27ff3ddc382c)

While there is no such endpoint, Aleoscan is open source and maintains its own backend DB. I found the corresponding [source code](https://github.com/HarukaMa/aleo-explorer/blob/4570ac026d1fec19030f1421a5d9b888029910fd/db/insert.py#L161) with transfer logic, which shows that Aleoscan transfers are parsed through the `credits.aleo` program:

```python
for transition in transitions:
    if transition.program_id == "credits.aleo":
        transfer_from = None
        transfer_to = None
        fee_from = None
        if str(transition.function_name) in ("transfer_public", "transfer_public_as_signer"):
            output = cast(FutureTransitionOutput, transition.outputs[0])
            future = cast(Future, output.future.value)
            transfer_from = str(DatabaseUtil.get_primitive_from_argument_unchecked(future.arguments[0]))
            transfer_to = str(DatabaseUtil.get_primitive_from_argument_unchecked(future.arguments[1]))
            amount = int(cast(u64, DatabaseUtil.get_primitive_from_argument_unchecked(future.arguments[2])))
        elif transition.function_name == "transfer_private_to_public":
            output = cast(FutureTransitionOutput, transition.outputs[1])
            future = cast(Future, output.future.value)
            transfer_to = str(DatabaseUtil.get_primitive_from_argument_unchecked(future.arguments[0]))
            amount = int(cast(u64, DatabaseUtil.get_primitive_from_argument_unchecked(future.arguments[1])))
        elif transition.function_name == "transfer_public_to_private":
            output = cast(FutureTransitionOutput, transition.outputs[1])
            future = cast(Future, output.future.value)
            transfer_from = str(DatabaseUtil.get_primitive_from_argument_unchecked(future.arguments[0]))
            amount = int(cast(u64, DatabaseUtil.get_primitive_from_argument_unchecked(future.arguments[1])))

...
```
 
The `future.arguments[x]` argument mapped to what's stored in the `OUTPUTS` column in `silver__transitions.sql`. But outputs aren't easy to extract: they're typed as strings containing **untyped** lazy JSON:
```json
"id": "7637462966247021801189592432668377709558076887603208062783993621527302681895field",
"type": "future",
"value": "{\n  program_id: credits.aleo,\n  function_name: transfer_public,\n  arguments: [\n    aleo14r3j2sak5n8dwy605j4ada040jajl9ycnxfzesly0urj9azg8sgs0ud6cl,\n    aleo17hwmqhh8annpgm3vqtpd336ww0ywjdeftlw2g3shl6xyt4x3jvxqfwzxhg,\n    1972629u64\n  ]\n}"
```

Using regex in absence of `PARSE_JSON()`, I extracted the arguments as an array whose order matched Aleoscan's. I'm comfortable trusting a scanner as the source of truth... but to [verify](https://aleoscan.io/transaction?id=at1ek6krcuwkcl7g3fnsary60vfz56nazfc0kwspx8k4ph3awzmlvps35vamw):

```sql
select tx_id, transition_id, sender, receiver, amount
from aleo_dev.core.fact_transfers 
where tx_id = 'at1ek6krcuwkcl7g3fnsary60vfz56nazfc0kwspx8k4ph3awzmlvps35vamw';
```

A few other notes:
- Data for private transfers returns null where appropriate.
- All the models in this PR are downstream of `silver__native_transfers.sql`.

## What's next
- Once this PR is merged, deploy new models to the frontend and crosschain repos
- Using the Aleoscan source, add more curated models for validator / staking actions
- Move ahead to [AN-5381](https://team-1612274056224.atlassian.net/browse/AN-5381), observability models


[AN-5381]: https://team-1612274056224.atlassian.net/browse/AN-5381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ