### PR TITLE
switching alerts from monthly to recent

### DIFF
--- a/.github/workflows/dbt_test_recent.yml
+++ b/.github/workflows/dbt_test_recent.yml
@@ -19,6 +19,7 @@ env:
   DATABASE: "${{ vars.DATABASE }}"
   WAREHOUSE: "${{ vars.WAREHOUSE }}"
   SCHEMA: "${{ vars.SCHEMA }}"
+  SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -45,3 +46,9 @@ jobs:
         run: |
           dbt run -m "aleo_models,tag:recent_test"
           dbt test -m "aleo_models,tag:recent_test"
+          
+        continue-on-error: true
+
+      - name: Log test results
+        run: |
+          python python/dbt_test_alert.py


### PR DESCRIPTION
Before building out robust testing, we were only receiving monthly Slack alerts in #alerts-alt-l1. The python script has already  been edited to the `dbt_test_recent.yml` URL, so this PR just adds the webhook and logs.