### PR TITLE
updated target scheduling, fixed test

### DIFF
--- a/data/github_actions__workflows.csv
+++ b/data/github_actions__workflows.csv
@@ -2,5 +2,5 @@ workflow_name,workflow_schedule
 dbt_run_streamline_blocks_realtime,"5,35 * * * *"
 dbt_run_core,"20,50 * * * *"
 dbt_test_tasks,"0,30 * * * *"
-dbt_run_non_core,"0 */3 * * *"
+dbt_run_non_core,"25 */3 * * *"
 dbt_test_recent,"20 */4 * * *"

--- a/data/github_actions__workflows.csv
+++ b/data/github_actions__workflows.csv
@@ -2,5 +2,5 @@ workflow_name,workflow_schedule
 dbt_run_streamline_blocks_realtime,"5,35 * * * *"
 dbt_run_core,"20,50 * * * *"
 dbt_test_tasks,"0,30 * * * *"
-dbt_run_non_core,"25,55 * * * *"
+dbt_run_non_core,"0 */3 * * *"
 dbt_test_recent,"20 */4 * * *"

--- a/models/gold/tests/tokens/test_core__token_registrations_recent.yml
+++ b/models/gold/tests/tokens/test_core__token_registrations_recent.yml
@@ -13,8 +13,8 @@ models:
           - not_null:
               where: token_id != '3443843282313283355522573239085696902919850365217539366784739393210722344986field'
           - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: hour
-              interval: 3
+              datepart: day
+              interval: 2
 
       - name: TX_ID_CREATED
         tests:


### PR DESCRIPTION
see: https://docs.flipsidecrypto.xyz/data/flipside-data/table-freshness-targets 

new tokens are not registered very often, just a few per day. some days 0. so I changed the lookback window to 2 days. We might also just remove the recency test on this but I imagine it'll become less of an issue over time.