### PR TITLE
An 5685 nonnative transfers

### DIFF
--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -9,7 +9,76 @@
     tags = ['core','full_test']
 ) }}
 
-SELECT
+WITH native_transfers AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        tx_succeeded,
+        transition_id,
+        index,
+        transfer_type,
+        sender,
+        receiver,
+        amount,
+        is_native,
+        token_id
+    FROM
+        {{ ref('silver__native_transfers') }}
+
+    {% if is_incremental() %}
+    WHERE
+        modified_timestamp >= DATEADD(
+            'minute',
+            -5,(
+                SELECT
+                    MAX(
+                        modified_timestamp
+                    )
+                FROM
+                    {{ this }}
+            )
+        )
+    {% endif %}
+),
+nonnative_transfers AS (
+    SELECT
+        block_id,
+        block_timestamp,
+        tx_id,
+        tx_succeeded,
+        transition_id,
+        index,
+        transfer_type,
+        sender,
+        receiver,
+        amount,
+        is_native,
+        token_id
+    FROM
+        {{ ref('silver__nonnative_transfers') }}
+
+    {% if is_incremental() %}
+    WHERE
+        modified_timestamp >= DATEADD(
+            'minute',
+            -5,(
+                SELECT
+                    MAX(
+                        modified_timestamp
+                    )
+                FROM
+                    {{ this }}
+            )
+        )
+    {% endif %}
+),
+all_transfers AS (
+    SELECT * FROM native_transfers
+    UNION ALL
+    SELECT * FROM nonnative_transfers
+)
+SELECT 
     block_id,
     block_timestamp,
     tx_id,
@@ -28,59 +97,5 @@ SELECT
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id
-FROM
-    {{ ref('silver__native_transfers') }}
-
-{% if is_incremental() %}
-WHERE
-    modified_timestamp >= DATEADD(
-        'minute',
-        -5,(
-            SELECT
-                MAX(
-                    modified_timestamp
-                )
-            FROM
-                {{ this }}
-        )
-    )
-{% endif %}
-
-UNION ALL
-
-SELECT
-    block_id,
-    block_timestamp,
-    tx_id,
-    tx_succeeded,
-    transition_id,
-    index,
-    transfer_type,
-    sender,
-    receiver,
-    amount,
-    is_native,
-    token_id,
-    {{ dbt_utils.generate_surrogate_key(
-        ['tx_id','transition_id','transfer_type']
-    ) }} AS fact_transfers_id,
-    SYSDATE() AS inserted_timestamp,
-    SYSDATE() AS modified_timestamp,
-    '{{ invocation_id }}' AS _invocation_id
-FROM
-    {{ ref('silver__nonnative_transfers') }}
-
-{% if is_incremental() %}
-WHERE
-    modified_timestamp >= DATEADD(
-        'minute',
-        -5,(
-            SELECT
-                MAX(
-                    modified_timestamp
-                )
-            FROM
-                {{ this }}
-        )
-    )
-{% endif %}
+FROM 
+    all_transfers

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -54,7 +54,7 @@ nonnative_transfers AS (
         receiver,
         amount,
         is_native,
-        token_id
+        token_id as token_address
     FROM
         {{ ref('silver__nonnative_transfers') }}
 
@@ -90,7 +90,7 @@ SELECT
     receiver,
     amount,
     is_native,
-    token_id,
+    token_id as token_address,
     {{ dbt_utils.generate_surrogate_key(
         ['tx_id','transition_id','transfer_type']
     ) }} AS fact_transfers_id,

--- a/models/gold/core/core__fact_transfers.sql
+++ b/models/gold/core/core__fact_transfers.sql
@@ -54,7 +54,7 @@ nonnative_transfers AS (
         receiver,
         amount,
         is_native,
-        token_id as token_address
+        token_id
     FROM
         {{ ref('silver__nonnative_transfers') }}
 

--- a/models/gold/core/core__fact_transfers.yml
+++ b/models/gold/core/core__fact_transfers.yml
@@ -42,7 +42,7 @@ models:
         description: "Whether the transfer is a native transfer (credits.aleo) or a non-native transfer (token_registry.aleo)."
         tests: 
           - dbt_expectations.expect_column_to_exist
-      - name: TOKEN_ID 
+      - name: TOKEN_ADDRESS 
         description: "Token address of the transfer."
         tests: 
           - dbt_expectations.expect_column_to_exist

--- a/models/gold/core/core__fact_transfers.yml
+++ b/models/gold/core/core__fact_transfers.yml
@@ -39,10 +39,10 @@ models:
         tests: 
           - dbt_expectations.expect_column_to_exist
       - name: IS_NATIVE
-        description: "Whether the transfer is a native transfer."
+        description: "Whether the transfer is a native transfer (credits.aleo) or a non-native transfer (token_registry.aleo)."
         tests: 
           - dbt_expectations.expect_column_to_exist
-      - name: TOKEN_ADDRESS 
+      - name: TOKEN_ID 
         description: "Token address of the transfer."
         tests: 
           - dbt_expectations.expect_column_to_exist

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -5,7 +5,7 @@
     incremental_strategy = 'merge',
     merge_exclude_columns = ['inserted_timestamp'],
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['noncore', 'full_test']
+    tags = ['core', 'full_test']
 ) }}
 
 WITH base AS (

--- a/models/silver/core/silver__nonnative_transfers.sql
+++ b/models/silver/core/silver__nonnative_transfers.sql
@@ -5,7 +5,7 @@
     incremental_strategy = 'merge',
     merge_exclude_columns = ['inserted_timestamp'],
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['noncore', 'full_test']
+    tags = ['core', 'full_test']
 ) }}
 
 WITH base AS (

--- a/models/silver/core/silver__nonnative_transfers.yml
+++ b/models/silver/core/silver__nonnative_transfers.yml
@@ -1,0 +1,90 @@
+version: 2
+models:
+  - name: silver__nonnative_transfers
+    description: Records of native token transfers on Aleo between wallets
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - TRANSITION_ID
+    columns:
+      - name: BLOCK_ID
+        description: "{{ doc('block_id') }}"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT  
+      - name: BLOCK_TIMESTAMP
+        description: "{{ doc('block_timestamp') }}"
+        tests:
+          - not_null:
+              where: inserted_timestamp < dateadd('hour', -1, SYSDATE())
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: TX_ID
+        description: "{{ doc('tx_id') }}"
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TRANSITION_ID
+        description: "{{ doc('transition_id') }}"
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: INDEX
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: NUMBER
+      - name: TX_SUCCEEDED
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - BOOLEAN
+      - name: TRANSFER_TYPE
+        description: "{{ doc('transfer_type') }}"
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SENDER
+        description: "Address that tokens are transferred from. If null, the sender is private and unresolvable."
+        tests: 
+          - not_null:
+              where: transfer_type IN ('transfer_public', 'transfer_public_as_signer', 'transfer_public_to_private')
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: RECEIVER
+        description: "Address that tokens are transferred to. If null, the receiver is private and unresolvable."
+        tests: 
+          - not_null:
+              where: transfer_type IN ('transfer_public', 'transfer_public_as_signer', 'transfer_private_to_public')
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: AMOUNT
+        description: "Number of tokens transferred. If null, the amount is private and unresolvable."
+        tests: 
+          - not_null:
+              where: transfer_type != 'transfer_private'
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT 


### PR DESCRIPTION
## Changes
- added `silver__nonnative_transfers.sql/yml` 
- refactored `core__fact_transfers.sql` to union native and nonnative transfers
- renamed `token_address` columns to `token_id` for consistency with `dim_token_registrations` (SILVER ONLY). Gold continues to be named `token_address` to avoid a deprecation notice

## Justification
To calculate the `net_token_accumulate` metric in Aleo scores, we want to include all token types. The output data of non-native token transfers changes the arg indices, with the token ID in index 0.