### PR TITLE
extended recency test for swaps to 1 day

### DIFF
--- a/models/gold/tests/defi/test_defi__swaps_recent.yml
+++ b/models/gold/tests/defi/test_defi__swaps_recent.yml
@@ -14,8 +14,8 @@ models:
         tests:
           - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: hour
-              interval: 3
+              datepart: day
+              interval: 1
 
       - name: BLOCK_ID
         tests:


### PR DESCRIPTION
This now matches the recency test lookback for liquidity actions. Purpose is to avoid false-alarms in the alerts-alt-l1 channel.