### PR TITLE
declutter alerts

### DIFF
--- a/python/dbt_test_alert.py
+++ b/python/dbt_test_alert.py
@@ -122,6 +122,9 @@ def send_alert(webhook_url):
 
 
 if __name__ == '__main__':
-
     webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
-    send_alert(webhook_url)
+    data = log_test_result()
+    
+    # Only send an alert if there are failures
+    if data['fail_count'] > 0:
+        send_alert(webhook_url)


### PR DESCRIPTION
This PR removes test successes from Slack. Now, only failed tests will notify the channel.