### PR TITLE
remove recency test

### DIFF
--- a/models/gold/defi/defi__fact_liquidity_pool_actions.yml
+++ b/models/gold/defi/defi__fact_liquidity_pool_actions.yml
@@ -7,9 +7,6 @@ models:
         description: "{{ doc('block_timestamp') }}"
         tests:
           - dbt_expectations.expect_column_to_exist
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 3
           - not_null
 
       - name: BLOCK_ID


### PR DESCRIPTION
this infrequently used table is pinging the alt-l1-alerts channel too often. will reinstate if bug reports are shared. 

Alternatively, I could bump the lookback to 7 days.