### PR TITLE
updated unique key in dim_programs

### DIFF
--- a/models/gold/core/core__dim_programs.sql
+++ b/models/gold/core/core__dim_programs.sql
@@ -15,7 +15,7 @@ WITH base AS (
         program,
         verifying_keys,
         {{ dbt_utils.generate_surrogate_key(
-            ['program_id']
+            ['program_id', 'edition']
         ) }} AS dim_program_id,
         SYSDATE() AS insert_timestamp,
         SYSDATE() AS modified_timestamp,


### PR DESCRIPTION
This PR adds `edition` to the surrogate key hash in `core.dim_programs`.

## Diagnostics
A duplicate UK has caused recent builds to fail:
```sql
select * 
from aleo.core.dim_programs 
where dim_program_id = 'f9a918c6c675a4e54a90deeb008b9dea';
```
These 2 rows are distinguished by their `edition` values. 

