### PR TITLE
Fix 2 Aleo test failures

### DIFF
--- a/models/gold/tests/defi/test_defi__swaps_recent.sql
+++ b/models/gold/tests/defi/test_defi__swaps_recent.sql
@@ -3,7 +3,7 @@
     tags = ['recent_test']
 ) }}
 
-WITH last_3_days AS (
+WITH last_7_days AS (
 
     SELECT
         block_date
@@ -12,7 +12,7 @@ WITH last_3_days AS (
         qualify ROW_NUMBER() over (
             ORDER BY
                 block_date DESC
-        ) = 3
+        ) = 7
 )
 SELECT
     *
@@ -23,5 +23,5 @@ WHERE
         SELECT
             block_date
         FROM
-            last_3_days
+            last_7_days
     )

--- a/models/gold/tests/defi/test_defi__swaps_recent.yml
+++ b/models/gold/tests/defi/test_defi__swaps_recent.yml
@@ -15,7 +15,7 @@ models:
           - not_null
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 3
+              interval: 7
 
       - name: BLOCK_ID
         tests:

--- a/models/silver/core/silver__programs.yml
+++ b/models/silver/core/silver__programs.yml
@@ -16,7 +16,6 @@ models:
         description: "The unique identifier of the program."
         tests:
           - not_null
-          - unique
       - name: EDITION
         description: "The version or edition number of the program."
         tests:


### PR DESCRIPTION
* Modified defi swaps recency to have a 7d lookback. As unusual as that sounds, the defi model only includes Arcane Finance. There's also AlphaSwap (just $108 of TVL) and native swapping in Leo Wallet, which we might need to curate.
* Modified test of `dim_programs` to allow dupes of `program_id` (`program_id` + `edition` = unique key)